### PR TITLE
Hops not used because of unset in get method.

### DIFF
--- a/src/Controller/Plugin/FlashMessenger.php
+++ b/src/Controller/Plugin/FlashMessenger.php
@@ -655,9 +655,5 @@ class FlashMessenger extends AbstractPlugin implements IteratorAggregate, Counta
             $this->messages[$namespace] = $messages;
             $namespaces[] = $namespace;
         }
-
-        foreach ($namespaces as $namespace) {
-            unset($container->{$namespace});
-        }
     }
 }


### PR DESCRIPTION
Calling getMessagesFromContainer() results in clearing the messages in the session, regarding the hops, defined when adding a message.
